### PR TITLE
[WIP] Use syobocal gem instead of forked repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rollbar"
 gem "rubicure"
 gem "sinatra"
 gem "slim"
-gem "syobocal", github: "sue445/syobocal", branch: "time_with_zone", ref: "76cf9b"
+gem "syobocal"
 
 group :development do
   gem "dotenv"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: git://github.com/sue445/syobocal.git
-  revision: 76cf9bed6c2cdb661b7f8760f055fbb401b8d7fb
-  ref: 76cf9b
-  branch: time_with_zone
-  specs:
-    syobocal (0.9.1)
-      activesupport
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -131,7 +122,6 @@ GEM
     slim (3.0.8)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 1.3.3, < 2.1)
-    syobocal (0.9.1)
     slop (3.6.0)
     syobocal (0.9.1)
     temple (0.8.0)
@@ -178,7 +168,7 @@ DEPENDENCIES
   simplecov
   sinatra
   slim
-  syobocal!
+  syobocal
   timecop
   webmock
 

--- a/lib/on_air_bot.rb
+++ b/lib/on_air_bot.rb
@@ -1,4 +1,5 @@
 require_relative "./bot"
+require_relative "./syobocal_ext"
 
 class OnAirBot < Bot
   NOTIFY_TITLE = "プリキュア".freeze

--- a/lib/syobocal_ext.rb
+++ b/lib/syobocal_ext.rb
@@ -1,0 +1,28 @@
+module ForceTimeWithZone
+  refine(Time) do
+    def parse(*args)
+      puts "called Time.zone.parse" # TODO: remove after
+      Time.zone.parse(*args)
+    end
+  end
+end
+
+require "syobocal"
+
+# module Syobocal::CalChk
+#   class << self
+#     using ForceTimeWithZone
+#   end
+# end
+
+# Syobocal::CalChk.class_eval do
+#   using ForceTimeWithZone
+# end
+
+# Syobocal::CalChk.singleton_class.class_eval do
+#   using ForceTimeWithZone
+# end
+
+Syobocal::CalChk.singleton_class.instance_eval do
+  using ForceTimeWithZone
+end

--- a/lib/syobocal_ext.rb
+++ b/lib/syobocal_ext.rb
@@ -9,6 +9,10 @@ end
 
 require "syobocal"
 
+module Syobocal::CalChk
+  using ForceTimeWithZone
+end
+
 # module Syobocal::CalChk
 #   class << self
 #     using ForceTimeWithZone
@@ -23,6 +27,6 @@ require "syobocal"
 #   using ForceTimeWithZone
 # end
 
-Syobocal::CalChk.singleton_class.instance_eval do
-  using ForceTimeWithZone
-end
+# Syobocal::CalChk.singleton_class.instance_eval do
+#   using ForceTimeWithZone
+# end


### PR DESCRIPTION
Wercker bundle installed cache is often broken :cry:

```
bundle install --path /pipeline/cache/bundle-install/ --jobs=4 --retry 3
The git source `git://github.com/sue445/syobocal.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
error: index file objects/pack/pack-2b483bcf5566cd2daca455215899df753a0ba676.idx is too small
error: index file objects/pack/pack-2b483bcf5566cd2daca455215899df753a0ba676.idx is too small
Fetching git://github.com/sue445/syobocal.git

error: index file objects/pack/pack-2b483bcf5566cd2daca455215899df753a0ba676.idx is too small
error: index file objects/pack/pack-2b483bcf5566cd2daca455215899df753a0ba676.idx is too small
error: refs/heads/master does not point to a valid object!
error: index file objects/pack/pack-2b483bcf5566cd2daca455215899df753a0ba676.idx is too small
error: index file objects/pack/pack-2b483bcf5566cd2daca455215899df753a0ba676.idx is too small
error: refs/heads/time_with_zone does not point to a valid object!
error: index file objects/pack/pack-2b483bcf5566cd2daca455215899df753a0ba676.idx is too small
error: index file objects/pack/pack-2b483bcf5566cd2daca455215899df753a0ba676.idx is too small
```