### PR TITLE
Use syobocal gem instead of forked repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rollbar"
 gem "rubicure"
 gem "sinatra"
 gem "slim"
-gem "syobocal", github: "sue445/syobocal", branch: "time_with_zone", ref: "76cf9b"
+gem "syobocal"
 
 group :development do
   gem "dotenv"

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rollbar"
 gem "rubicure"
 gem "sinatra"
 gem "slim"
-gem "syobocal"
+gem "syobocal", "0.9.1" # app contains monkey patch
 
 group :development do
   gem "dotenv"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ DEPENDENCIES
   simplecov
   sinatra
   slim
-  syobocal
+  syobocal (= 0.9.1)
   timecop
   webmock
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: git://github.com/sue445/syobocal.git
-  revision: 76cf9bed6c2cdb661b7f8760f055fbb401b8d7fb
-  ref: 76cf9b
-  branch: time_with_zone
-  specs:
-    syobocal (0.9.1)
-      activesupport
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -131,7 +122,6 @@ GEM
     slim (3.0.8)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 1.3.3, < 2.1)
-    syobocal (0.9.1)
     slop (3.6.0)
     syobocal (0.9.1)
     temple (0.8.0)
@@ -178,7 +168,7 @@ DEPENDENCIES
   simplecov
   sinatra
   slim
-  syobocal!
+  syobocal
   timecop
   webmock
 

--- a/lib/on_air_bot.rb
+++ b/lib/on_air_bot.rb
@@ -1,4 +1,5 @@
 require_relative "./bot"
+require_relative "./syobocal_ext"
 
 class OnAirBot < Bot
   NOTIFY_TITLE = "プリキュア".freeze

--- a/lib/syobocal_ext.rb
+++ b/lib/syobocal_ext.rb
@@ -1,0 +1,36 @@
+# rubocop:disable all This is monkey patch!
+
+module ParseWithTimeWithZone
+  def parse(xml)
+    xml = REXML::Document.new(xml)
+
+    result = Syobocal::CalChk::Result.new
+
+    syobocal = xml.elements['syobocal']
+    result.url = syobocal.attribute("url").to_s
+    result.version = syobocal.attribute("version").to_s
+    result.last_update = Time.parse(syobocal.attribute("LastUpdate").to_s)
+    result.spid = syobocal.attribute("SPID").to_s
+    result.spname = syobocal.attribute("SPNAME").to_s
+
+    xml.elements.each('syobocal/ProgItems/ProgItem'){|item|
+      result << {
+        :pid => item.attribute("PID").to_s.to_i,
+        :tid => item.attribute("TID").to_s.to_i,
+        :st_time => Time.zone.parse(item.attribute("StTime").to_s), # monkey patched
+        :ed_time => Time.zone.parse(item.attribute("EdTime").to_s), # monkey patched
+        :ch_name => item.attribute("ChName").to_s,
+        :ch_id => item.attribute("ChID").to_s.to_i,
+        :count => item.attribute("Count").to_s.to_i,
+        :st_offset => item.attribute("StOffset").to_s.to_i,
+        :sub_title => item.attribute("SubTitle").to_s,
+        :title => item.attribute("Title").to_s,
+        :prog_comment => item.attribute("ProgComment").to_s
+      }
+    }
+
+    result
+  end
+end
+
+Syobocal::CalChk.singleton_class.send(:prepend, ParseWithTimeWithZone)


### PR DESCRIPTION
Wercker bundle installed cache is often broken :cry:

```
bundle install --path /pipeline/cache/bundle-install/ --jobs=4 --retry 3
The git source `git://github.com/sue445/syobocal.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
error: index file objects/pack/pack-2b483bcf5566cd2daca455215899df753a0ba676.idx is too small
error: index file objects/pack/pack-2b483bcf5566cd2daca455215899df753a0ba676.idx is too small
Fetching git://github.com/sue445/syobocal.git

error: index file objects/pack/pack-2b483bcf5566cd2daca455215899df753a0ba676.idx is too small
error: index file objects/pack/pack-2b483bcf5566cd2daca455215899df753a0ba676.idx is too small
error: refs/heads/master does not point to a valid object!
error: index file objects/pack/pack-2b483bcf5566cd2daca455215899df753a0ba676.idx is too small
error: index file objects/pack/pack-2b483bcf5566cd2daca455215899df753a0ba676.idx is too small
error: refs/heads/time_with_zone does not point to a valid object!
error: index file objects/pack/pack-2b483bcf5566cd2daca455215899df753a0ba676.idx is too small
error: index file objects/pack/pack-2b483bcf5566cd2daca455215899df753a0ba676.idx is too small
```