### PR TITLE
Use drecom image instead of official

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -3,7 +3,7 @@
 # https://registry.hub.docker.com/_/ruby/
 # If you want to use a specific version you would use a tag:
 # ruby:2.2.2
-box: ruby:2.4.1
+box: drecom/ubuntu-ruby:2.4.1
 # You can also use services such as databases. Read more on our dev center:
 # http://devcenter.wercker.com/docs/services/index.html
 services:


### PR DESCRIPTION
```
export WERCKER_STEP_ROOT="/pipeline/script-408ab15c-7a77-41d3-b18e-2c71056f6a15"
export WERCKER_STEP_ID="script-408ab15c-7a77-41d3-b18e-2c71056f6a15"
export WERCKER_STEP_OWNER="wercker"
export WERCKER_STEP_NAME="script"
export WERCKER_REPORT_NUMBERS_FILE="/report/script-408ab15c-7a77-41d3-b18e-2c71056f6a15/numbers.ini"
export WERCKER_REPORT_MESSAGE_FILE="/report/script-408ab15c-7a77-41d3-b18e-2c71056f6a15/message.txt"
export WERCKER_REPORT_ARTIFACTS_DIR="/report/script-408ab15c-7a77-41d3-b18e-2c71056f6a15/artifacts"
source "/pipeline/script-408ab15c-7a77-41d3-b18e-2c71056f6a15/run.sh" < /dev/null
*** Error in `/pipeline/cache/bundle-install/ruby/2.4.0/bin/rspec': free(): invalid next size (fast): 0x000000000458fcc0 ***
/pipeline/script-408ab15c-7a77-41d3-b18e-2c71056f6a15/run.sh: line 2:  1767 Aborted                 (core dumped) bundle exec rspec
```

https://app.wercker.com/sue445/cure-mastodon-bots/runs/build-rspec/59cf2090c070350001627f22?step=59cf209ccc579c00010be264